### PR TITLE
#66 BOJ_16928_뱀과사다리게임_HS

### DIFF
--- a/Gold/Gold5/BOJ_16928_뱀과사다리게임_HS.java
+++ b/Gold/Gold5/BOJ_16928_뱀과사다리게임_HS.java
@@ -1,0 +1,77 @@
+package boj_class03;
+
+import java.io.*;
+import java.util.*;
+
+public class Main_G5_16928_뱀과사다리게임 {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		st = new StringTokenizer(br.readLine(), " ");
+		int N = Integer.parseInt(st.nextToken()); // 사다리
+		int M = Integer.parseInt(st.nextToken()); // 뱀
+		
+		Map<Integer, Integer> ladders = new HashMap<>();
+		Map<Integer, Integer> snakes = new HashMap<>();
+		for(int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			ladders.put(from, to);
+		}
+		for(int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			snakes.put(from, to);
+		}
+		
+		boolean[] visited = new boolean[101];
+		int minCount = Integer.MAX_VALUE;
+		boolean find = false;
+		ArrayDeque<Integer[]> queue = new ArrayDeque<>();
+		visited[1] = true;
+		queue.offer(new Integer[] {1, 1});
+		
+		while(!queue.isEmpty()) {
+			Integer[] cur = queue.poll();
+			int pos = cur[0];
+			int count = cur[1];
+			
+			for(int k = 1; k <= 6; k++) {
+				int next = pos + k;
+				
+				if(next >= 100) {
+					minCount = count; // 찾았다
+					find = true;
+					break;
+				}
+				
+				if(visited[next]) continue;
+				
+				if(ladders.containsKey(next)) {
+					int newNext = ladders.get(next);
+					visited[next] = true;
+					visited[newNext] = true; // 다음에 이 자리 오면 이미 방문해서 같은 결과 출력하니까
+					queue.offer(new Integer[] {newNext, count + 1});
+				}else if(snakes.containsKey(next)) {
+					int newNext = snakes.get(next);
+					visited[next] = true;
+					visited[newNext] = true; // 다음에 이 자리 오면 이미 방문해서 같은 결과 출력하니까
+					queue.offer(new Integer[] {newNext, count + 1});
+				}else {
+					visited[next] = true;
+					queue.offer(new Integer[] {next, count + 1});
+				}
+				
+			}
+			
+			if(find) break;
+		}
+		
+		System.out.println(minCount);
+	}
+}


### PR DESCRIPTION
# [뱀과 사다리 게임 (GOLD 5)](https://www.acmicpc.net/problem/16928)

## 문제 풀이 방법
1. 주사위 눈 (1~6), 이동하는 거리 최대 100 이라고 생각하고 완전 탐색해도 되겠다고 판단해 BFS로 풀었다.
2. 이 때 사다리와 뱀의 이동 좌표는 HashMap을 두 개 선언해서 Key-Value 쌍으로 가지고 BFS 탐색 시 이용했다.
3. BFS는 같은 깊이를 전부 순회하고 그 다음 깊이로 이동하므로, 다음과 같은 특징을 이용할 수 있었다.
- 먼저 찾은 count 값이 최소를 보장
- 방문 체크를 해두면, 다음에 방문했을 때는 현재랑 같은 count거나 더 이후이므로 같은 케이스라 볼 필요 없음