### PR TITLE
#161 BOJ_15663_N과M(9) _TY

### DIFF
--- a/Silver/Silver2/BOJ_15663_N과M(9) _TY.java
+++ b/Silver/Silver2/BOJ_15663_N과M(9) _TY.java
@@ -1,0 +1,69 @@
+package silver2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class N15663_Main2 {
+
+	public static int N;
+	public static int M;
+	public static StringBuilder sb;
+	public static int[] arr;
+	public static boolean[] isSelected;
+	public static HashSet<String> set;
+	public static List<String> list;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+		sb = new StringBuilder();
+
+		StringTokenizer st = new StringTokenizer(in.readLine()," ");
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		arr = new int[N];
+		st = new StringTokenizer(in.readLine()," ");
+		for (int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+
+		Arrays.sort(arr);
+
+		set = new HashSet<>();
+
+		isSelected = new boolean[N];
+		
+		list = new ArrayList<>();
+		
+		perm(0,"");
+		
+		for(String result : list) {
+			sb.append(result).append("\n");
+		}
+
+		System.out.println(sb);
+	}
+
+	private static void perm(int cnt,String result) {
+		if(cnt == M) {
+			if(!set.contains(result)) {
+				set.add(result);
+				list.add(result);				
+			}
+			return;
+		}
+		for (int i = 0; i < N; i++) {
+			if(isSelected[i]) continue;
+			isSelected[i] = true;
+			perm(cnt+1, result + arr[i]+" ");
+			isSelected[i] = false;
+		}
+
+	}
+}


### PR DESCRIPTION
### 접근 방법
문제에서 길이가 M인 수열을 모두 구하라고 하였기 때문에 `수열`로 접근하였으며<br/>
중복되는 수열은 여러 번 출력하면 안 된다는 조건이 있어 `HashSet`을 이용해 중복을 제거했습니다.<br/>
또한, 사전 순으로 출력해야되므로 permutation전에 정렬해주었습니다.

### 풀이 방법
#### 기존 
permutation을 통해 구해진 결과들을 Hashset에 담아 중복을 제거했습니다.
```
		List<String> list = new ArrayList<>(set);
		Collections.sort(list,new Comparator<String>() {

			@Override
			public int compare(String s1, String s2) {
				
				String arr1[] = s1.split(" ");
				String arr2[] = s2.split(" ");
	
				int size = arr1.length;
				for (int i = 0; i < size; i++) {
					int n1 = Integer.parseInt(arr1[i]);
					int n2 = Integer.parseInt(arr2[i]);
					if(n1==n2)
						continue;
					else
						return n1-n2;
				}
				return 0;
			}
		});
```
하지만 Hashset은 사전 순으로 출력되지 않아 출력 전에 다시 ArrayList로 바꾼 뒤 
Collection.sort()의 Comparator를 통해 사전순으로 정렬하도록 커스텀 하였습니다.
Hashset을 .split(" ")을 통해 앞에서 부터 하나씩 int형으로 바꿔가며 크기를 비교했습니다.
하지만 이러한 방법은 String을 Integer로 변환하는데 시간이 오래 걸려 좋은 방법이 아니었습니다.<br/>

#### 수정한 코드
HashSet에 저장된 결과를 다시 정렬하는 대신 HashSet은 오직 중복검사하는데에만 사용하고
새로 List를 만들어 정렬된 상태로 값을 저장하는 방식으로 바꿨습니다
results라는 ArraysList에 추가하기 전에 set.contains(result)를 통해 중복된 값인지 체크해주었습니다.
```
	private static void perm(int cnt, String result) {
		if(cnt == M) {
			if(!set.contains(result)) {
				set.add(result);
				results.add(result);				
			}
			return;
		}
		
		for (int i = 0; i < N; i++) {
			if(isSelected[i]) continue;
			
			isSelected[i] = true;
			perm(cnt+1, result+arr[i]+" ");
			isSelected[i] = false;
		}
	}
```
### 성능
![image](https://user-images.githubusercontent.com/68904159/205481271-1e2d1ea3-ee10-4398-882d-806d02f548c7.png)
