### PR TITLE
#1202 BOJ_1052_물병_DS

### DIFF
--- a/Silver/Silver1/BOJ_1052_물병_DS.java
+++ b/Silver/Silver1/BOJ_1052_물병_DS.java
@@ -1,0 +1,43 @@
+package baekjoon.sliver.sliver1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1052_물병 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(in.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		
+		String bN = Integer.toBinaryString(N);
+		int cnt =0;
+		int ans =0;
+		int start = -1;
+		for(int i=0;i<bN.length();i++) {
+			if(cnt==K) {
+				start = i; 
+				break;
+			}
+			if(bN.charAt(i)=='1') cnt++;
+		}
+		if(start==-1) ans=0;
+		else {
+			boolean op = true;
+			for(int i=bN.length()-1;i>=start;i--) {
+				if(op&&bN.charAt(i)=='1') {
+					ans += Math.pow(2, bN.length()-i-1);
+					op = false;
+				}
+				if(!op&&bN.charAt(i)=='0') {
+					ans += Math.pow(2, bN.length()-i-1);
+				}
+			}
+		}
+		
+		System.out.println(ans);
+	}
+
+}


### PR DESCRIPTION
## 성능
![image](https://user-images.githubusercontent.com/100937653/207040564-1ebe732b-78aa-4120-87af-2841cf428ea5.png)
## 풀이방법
물병이 합쳐지면 1, 2, 4, 8, 32 ~~~~으로 합쳐지니까 2진법으로 바꿔서 1의개수를 한번에 옮길수 있는 K개로 만들었습니다.