### PR TITLE
#156 BOJ_1932_정수삼각형_TY

### DIFF
--- a/Silver/Silver1/BOJ_1932_정수삼각형_TY.java
+++ b/Silver/Silver1/BOJ_1932_정수삼각형_TY.java
@@ -1,0 +1,65 @@
+package silver1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.StringTokenizer;
+import java.util.concurrent.ForkJoinPool;
+
+public class N1932_Main {
+	public static int N;
+	public static int max;
+	public static int[] list;
+	public static int[] sum;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer st;
+
+		st = new StringTokenizer(in.readLine(), " ");
+		N = Integer.parseInt(st.nextToken());
+		
+		int[] a = new int[1];
+		a[0] = Integer.parseInt(in.readLine());
+		
+		int[] b;
+		for (int i = 2; i <= N; i++) {
+			b = new int[i];
+			st = new StringTokenizer(in.readLine(), " ");
+			for (int j = 0; j < i; j++) {
+				b[j] = Integer.parseInt(st.nextToken());
+			}
+			
+			for (int j = 0; j < i; j++) {
+				int left = -1;
+				if(j>0) 
+					left = a[j-1]+b[j];	
+				
+				int right = -1;
+				if(j<i-1) 
+					right = a[j]+b[j];					
+				
+				b[j] = Math.max(left, right);
+			}
+			
+//			System.out.println(Arrays.toString(b));
+			
+			a = new int[i];
+			for (int j = 0; j < i; j++) {
+				a[j] = b[j];
+			}
+		}
+		
+		int max = Integer.MIN_VALUE;
+		for (int i = 0; i < N; i++) {
+			if(a[i] > max)
+				max = a[i];
+		}
+		
+		System.out.println(max);
+	}
+}


### PR DESCRIPTION
## 풀이 방법
![image](https://user-images.githubusercontent.com/68904159/208233414-b2efb54b-2c40-41e6-9b59-543229650c40.png)

- BFS와 DP를 이용해서 풀려고 했지만 계속 메모리 초과가 발생해 점화식을 이용해 푸는 방법을 이용했습니다. 
- 하지만 A배열과 B배열을 바꿔주는 부분이 존재해 성능적으로 우수하지는 못 한것 같습니다.
```
a = new int[i];
for (int j = 0; j < i; j++) {
	a[j] = b[j];
}
```
## 성능
![image](https://user-images.githubusercontent.com/68904159/208233423-aa3ec85a-b2a8-4b4d-bb65-cb526d89a959.png)
