### PR TITLE
#168 BOJ_1052_물병

### DIFF
--- a/Silver/Silver1/BOJ_1052_물병_JH.java
+++ b/Silver/Silver1/BOJ_1052_물병_JH.java
@@ -1,0 +1,47 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1052_물병_JH {
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		
+		int min = -1;
+		
+		for(int i = 1; i <= K; i++) {  // K개까지의 물병만 만들 수 있음
+			
+			
+			if(N == 0) {  // 물병 다 만들었으면 break
+				min = 0;
+				break;
+			}
+			
+			
+			int m = 0;
+			while(true) {
+				if(N <= Math.pow(2, m)) {
+					break;
+				}
+				m++;
+			}
+			m -= 1;  // N보다 작은 최대 제곱수
+			if(i == K) {  // 마지막 병인데 다 못만들면
+				min = (int) Math.pow(2, m+1) - N;
+				break;
+			}
+			
+			N = N - (int) Math.pow(2, m);  // 최대 제곱수로 물병 하나 만들어서 빼줌
+			
+		}
+		
+		System.out.println(min);
+	}
+}


### PR DESCRIPTION
## 풀이방식

![image](https://user-images.githubusercontent.com/60592289/210091752-c6fd6870-856d-40f4-936e-aa2963e8762e.png)


👉 비트마스킹이 더 쉬울거같긴한데 저는 그냥 수학적방법으로 접근했습니다
👉 현재 물병개수를 가장 많이 사용해서(최대한의 2의 제곱수를 빼서) 1병씩 줄여나가면서, 
K번째 병이 되기 전에 물병을 다 합치면 사야할 물병 개수를 0으로 하고 
그렇지 않으면 K번째에서 사야할 최소한의 물병개수를 계산하여 구했습니다. 
👉 헷갈린 부분

- N <= K여도 K개 이하 물병은 다 가능하기때문에 고려해주지않아도됨
- 2^0부터 시작해야함(1병짜리는 굳이 합치지않아도됨)
